### PR TITLE
Fix /stats

### DIFF
--- a/bot/src/main/java/xyz/funtimes909/serverseekerv2_discord_bot/commands/Stats.java
+++ b/bot/src/main/java/xyz/funtimes909/serverseekerv2_discord_bot/commands/Stats.java
@@ -15,7 +15,7 @@ public class Stats {
         JsonObject object = APIUtils.getAsObject(response);
 
         if (object == null) return;
-        int serverCount = object.get("servers").getAsInt();
+        int serverCount = object.get("all").getAsInt();
 
         MessageEmbed embed = new EmbedBuilder()
                 .setTitle("Stats")


### PR DESCRIPTION
The original stats command was expecting the API to return the JSON object `{"servers": "250863"}`, but in [this commit](https://github.com/Funtimes909/ServerSeekerV2-PyAPI/commit/8759ac216f9fd35351314da5f5408a1f2aa6b5b7) of the API that structure got changed.

This PR patches the code to work around the new structure, making the /stats command work again