### PR TITLE
make /takedown use a POST request

### DIFF
--- a/bot/src/main/java/xyz/funtimes909/serverseekerv2_discord_bot/commands/Takedown.java
+++ b/bot/src/main/java/xyz/funtimes909/serverseekerv2_discord_bot/commands/Takedown.java
@@ -33,7 +33,7 @@ public class Takedown {
 
             // Remove entries from the database if requested
             if (event.getOption("remove-entries") != null && event.getOption("remove-entries").getAsBoolean()) {
-                APIUtils.query("takedown?address=" + address);
+                APIUtils.post("takedown?address=" + address);
             }
 
             event.getHook().sendMessage("Added " + address + " to the exclude file").queue();

--- a/bot/src/main/java/xyz/funtimes909/serverseekerv2_discord_bot/util/APIUtils.java
+++ b/bot/src/main/java/xyz/funtimes909/serverseekerv2_discord_bot/util/APIUtils.java
@@ -28,6 +28,23 @@ public class APIUtils {
         }
     }
 
+    public static JsonElement post(String query) {
+        System.out.println(Main.apiUrl + query);
+        try (HttpClient client = HttpClient.newHttpClient()) {
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(Main.apiUrl + query))
+                    .POST(HttpRequest.BodyPublishers.noBody())
+                    .header("X-Auth-Key",  Main.apiToken)
+                    .build();
+
+            HttpResponse<String> response = client.sendAsync(request, HttpResponse.BodyHandlers.ofString()).join();
+            if (response.statusCode() == 429) return null;
+            return JsonParser.parseString(response.body());
+
+        }
+    }
+
     public static JsonArray getAsArray(JsonElement response) {
         if (response == null || !response.isJsonArray()) {
             return null;


### PR DESCRIPTION
in [this commit](https://github.com/Funtimes909/ServerSeekerV2-PyAPI/commit/e9f21e092f27d38860c444406bf53a17baffbb4f) of the PyAPI the /takedown endpoint got changed from a GET endpoint to a POST one, this pr fixes the bot to send a POST request to that endpoint.